### PR TITLE
Change the style of the svg sprite and add aria-hidden attribute

### DIFF
--- a/bin/spritesh.js
+++ b/bin/spritesh.js
@@ -16,7 +16,7 @@ program
 const SRC_FOLDER = program.input || '.';
 const DEST_FILE = program.output || 'sprite.svg';
 const ID_PREFIX = program.prefix || '';
-const VIEWBOX = program.viewbox || null; 
+const VIEWBOX = program.viewbox || null;
 const QUIET = program.quiet || false;
 
 const log = (message) => {
@@ -100,7 +100,8 @@ const filterFile = (file) => {
 };
 
 const getSpriteContent = (contents) => {
-  return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="display:none">'
+  return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" '
+    + 'style="width: 0; height: 0; visibility: hidden; position: absolute;" aria-hidden="true">'
     + contents.join('')
     + '</svg>';
 };


### PR DESCRIPTION
This PR addresses https://github.com/edenspiekermann/sprite.sh/issues/23 and changes the way the SVG sprite is being hidden. 
Since the `display: none` declaration is now removed, an `aria-hidden="true"` attribute is added to "hide" the sprite on screen readers.